### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,8 @@ jobs:
   lint-and-test:
     name: 🔍 Lint, Format & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: ⬇️ Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/guillaumecatel/website/security/code-scanning/1](https://github.com/guillaumecatel/website/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `lint-and-test` job in the workflow file. This block should explicitly set the permissions to `contents: read`, as the job only requires read access to the repository contents. This change ensures that the GITHUB_TOKEN used in the job has the minimal permissions necessary, reducing the risk of unintended access or modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
